### PR TITLE
Added a fix for the delay before the landing sound plays

### DIFF
--- a/Assets/Scenes/Main Room.unity
+++ b/Assets/Scenes/Main Room.unity
@@ -509,6 +509,10 @@ PrefabInstance:
       propertyPath: WalkingSound
       value: 
       objectReference: {fileID: 1039181845}
+    - target: {fileID: 6116328779957926450, guid: f85509eabcd7907429c73f8fc4bb8513, type: 3}
+      propertyPath: LandingSoundStartTime
+      value: 0.21
+      objectReference: {fileID: 0}
     - target: {fileID: 8099647083979846304, guid: f85509eabcd7907429c73f8fc4bb8513, type: 3}
       propertyPath: LowHealthSound
       value: 

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -26,6 +26,7 @@ public class PlayerController : MonoBehaviour
     public AudioSource JumpSound;
     public AudioSource CrouchSound;
     public AudioSource LandingSound;
+    public float LandingSoundStartTime = 0.35f;
 
     private void Start()
     {
@@ -148,6 +149,7 @@ public class PlayerController : MonoBehaviour
     {
         if(collision.gameObject.tag == "Ground")
         {
+            LandingSound.time = LandingSoundStartTime;
             LandingSound.Play();
         }
 

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -26,7 +26,7 @@ public class PlayerController : MonoBehaviour
     public AudioSource JumpSound;
     public AudioSource CrouchSound;
     public AudioSource LandingSound;
-    public float LandingSoundStartTime = 0.35f;
+    private const float LandingSoundStartTime = 0.21f;
 
     private void Start()
     {


### PR DESCRIPTION
Added one line of code to start the landing sound after the silence created upon importing the audio file into Unity ends.

Added a variable for testing purposes to easily determine the best time at which to start the landing sound.